### PR TITLE
"TC weapons break on preview" fixed

### DIFF
--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -25,7 +25,6 @@ function mod:init(options)
 	require(self.scriptPath.."libs/spaceDamageObjects")
 	require(self.scriptPath.."libs/status")
 	require(self.scriptPath.."libs/weaponArmed")
-	require(self.scriptPath.."libs/weaponPreview")
 	require(self.scriptPath .."libs/worldConstants")
 end
 


### PR DESCRIPTION
by removing the `require()` that called the "weaponPreview" library on all mods, and instead, making it only be called on the mods that it needs to be called, I isolated the issue and made most mods TC-friendly

**more fixes would be needed to solve the issue, but this is a bandaid approach to it.**
mods that still have the issue:
1. Ancient Draconids
2. Blob Pack
3. Eldritch Mechs
4. Gunk Keepers(WIP)
5. Pokemon
6. Secret Squad IV